### PR TITLE
Fixed workflow events

### DIFF
--- a/.github/workflows/solid-vite.yml
+++ b/.github/workflows/solid-vite.yml
@@ -1,11 +1,17 @@
 name: Solid Vite Pipeline
 on:
-  workflow_run:
-    workflows: ['Solid Renderer Pipeline']
-    types:
-      - completed
-    branches:
-      - main
+  workflow_call:
+    inputs:
+      publish:
+        description: Publish?
+        required: false
+        type: boolean
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish?
+        required: false
+        type: boolean
 defaults:
   run:
     working-directory: packages/frameworks/solid-vite
@@ -20,7 +26,7 @@ jobs:
         run: yarn check
         working-directory: packages/frameworks/solid-vite
       - name: Publish to NPM
-        if: github.event_name == 'release'
+        if: inputs.publish
         run: yarn npm publish
         working-directory: packages/frameworks/solid-vite
         env:

--- a/.github/workflows/solid.yml
+++ b/.github/workflows/solid.yml
@@ -14,6 +14,12 @@ on:
     types: [published]
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish?
+        required: false
+        type: boolean
 defaults:
   run:
     working-directory: packages/renderers/solid
@@ -28,8 +34,13 @@ jobs:
         run: yarn check
         working-directory: packages/renderers/solid
       - name: Publish to NPM
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || inputs.publish
         run: yarn npm publish
         working-directory: packages/renderers/solid
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  solid-vite-workflow:
+    needs: solid-workflow
+    uses: ./.github/workflows/solid-vite.yml
+    with:
+      publish: ${{ github.event_name == 'release' || inputs.publish }}


### PR DESCRIPTION
In the original workflow files, the framework package only gets published when a release is published, but it doesn't depend on any release events, so it must have not worked, or GitHub actions worked differently back then.

This PR fixes it by converting the CD pipeline for the framework package from a pull system to a push system.
In other words, instead of checking if the renderer package pipeline has run, the renderer package pipeline will call the framework package pipeline.

This allows for the renderer package pipeline to provide an input for whether or not to publish, and for the pipelines to be called manually if something goes wrong.