### PR TITLE
Added typescript support for code snippets

### DIFF
--- a/packages/frameworks/solid-vite/package.json
+++ b/packages/frameworks/solid-vite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "storybook-solidjs-vite",
   "type": "module",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "description": "Storybook for SolidJS and Vite: Develop SolidJS in isolation with Hot Reloading.",
   "keywords": [
     "storybook"

--- a/packages/renderers/solid/package.json
+++ b/packages/renderers/solid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "storybook-solidjs",
   "type": "module",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "description": "Storybook SolidJS renderer",
   "keywords": [
     "storybook"

--- a/packages/renderers/solid/src/docs/sourceDecorator.test.tsx
+++ b/packages/renderers/solid/src/docs/sourceDecorator.test.tsx
@@ -61,6 +61,19 @@ test('component with method prop', () => {
   `);
 });
 
+test('component with typescript', () => {
+  const newSrc = generateSolidSource(
+    'Component',
+    '{ args: { double: (x: number) => { return x * 2; } } }',
+  );
+
+  expect(newSrc).toMatchInlineSnapshot(`
+    "<Component double={(x: number) => {
+      return x * 2;
+    }} />"
+  `);
+});
+
 test('component missing story config', () => {
   const newSrc = () => generateSolidSource('Component', '5 + 4');
 

--- a/packages/renderers/solid/src/docs/sourceDecorator.tsx
+++ b/packages/renderers/solid/src/docs/sourceDecorator.tsx
@@ -159,7 +159,7 @@ interface SolidProps {
  * The source code will be in the form of a `Story` object.
  */
 function parseProps(src: string): SolidProps {
-  const ast = parser.parseExpression(src, { plugins: ['jsx'] });
+  const ast = parser.parseExpression(src, { plugins: ['jsx', 'typescript'] });
   if (ast.type != 'ObjectExpression') throw 'Expected `ObjectExpression` type';
   // Find args property.
   const args_prop = ast.properties.find((v: any) => {


### PR DESCRIPTION
I failed to realize that Babel doesn't just have TypeScript support out of the box and it had to be enabled with a plugin.

This PR fixes that and adds a test for TypeScript in stories.